### PR TITLE
add load_driver function to junos module

### DIFF
--- a/napalm_junos/__init__.py
+++ b/napalm_junos/__init__.py
@@ -1,0 +1,2 @@
+def load_driver():
+    return JunOSDriver


### PR DESCRIPTION
This adds the load_driver funtion to the napalm_junos module so the driver
can be automatically loaded by napalm base.   The load_driver module will
simply return the base class required to allow napalm to instatiate the
network driver

https://github.com/napalm-automation/napalm-base/pull/7
