### PR TITLE
FIX: Interface speed

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -156,17 +156,23 @@ class JunOSDriver(NetworkDriver):
             result[iface] = {
                 'is_up': interfaces[iface]['is_up'],
                 'is_enabled': interfaces[iface]['is_enabled'],
-                'description': interfaces[iface]['description'] or u'',
-                'last_flapped': interfaces[iface]['last_flapped'] or -1,
-                'mac_address': unicode(interfaces[iface]['mac_address'])
+                'description': (interfaces[iface]['description'] or u''),
+                'last_flapped': float((interfaces[iface]['last_flapped'] or -1)),
+                'mac_address': unicode((interfaces[iface]['mac_address'] or '')),
+                'speed': -1
             }
-            result[iface]['last_flapped'] = float(result[iface]['last_flapped'])
+            # result[iface]['last_flapped'] = float(result[iface]['last_flapped'])
 
-            match = re.search(r'\d+', interfaces[iface]['speed'] or '')
-            if match is not None:
-                result[iface]['speed'] = int(match.group(0))
-            else:
-                result[iface]['speed'] = -1
+            match = re.search(r'(\d+)(\w*)', interfaces[iface]['speed'] or u'')
+            if match is None:
+                continue
+            speed_value = self._convert(int, match.group(1), -1)
+            if speed_value == -1:
+                continue
+            speed_unit = match.group(2)
+            if speed_unit.lower() == 'gbps':
+                speed_value *= 1000
+            result[iface]['speed'] = speed_value
 
         return result
 


### PR DESCRIPTION
The speed is not always specified in Mbps:

``` xml

<interface-information xmlns="http://xml.juniper.net/junos/13.3R6/junos-interface" junos:style="normal">
    <physical-interface>
        <name>ae1</name>
        <admin-status junos:format="Enabled">up</admin-status>
        <oper-status>up</oper-status>
        <local-index>129</local-index>
        <snmp-index>509</snmp-index>
        <link-level-type>Ethernet</link-level-type>
        <mtu>9192</mtu>
        <source-filtering>disabled</source-filtering>
        <speed>20Gbps</speed>
        .
        .
        .
    </physical-interface>
</interface-information>
```

Right now, the method `get_interfaces` only returns the value, instead of considering the unit as well.
