### PR TITLE
Change 'uptime' default value to str instead of int. #24

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -145,7 +145,7 @@ class JunOSDriver(NetworkDriver):
 
         output = self.device.facts
 
-        uptime = 0
+        uptime = '0'
         if 'RE0' in output:
             uptime = output['RE0']['up_time']
 


### PR DESCRIPTION
Make default uptime str instead of int since convert_uptime_string_seconds() expects a str. This will fix #24 
