### PR TITLE
Fix for #27 and #39

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -339,10 +339,15 @@ class JunOSDriver(NetworkDriver):
         """
         address_family_mapping = {
             'inet': 'ipv4',
-            'inet6': 'ipv6'
+            'inet6': 'ipv6',
+            'inetflow': 'flow'
         }
         family = table.split('.')[-2]
-        return address_family_mapping[family]
+        try:
+            address_family = address_family_mapping[family]
+        except KeyError:
+            address_family = family
+        return address_family
 
     def _parse_route_stats(self, neighbor):
         data = {}


### PR DESCRIPTION
`address_family_mapping` is for unified family names across different vendors. If there is no mapping, family should have the same name as the table. In almost all cases it will be the same ex. evpn, l2vpn, l3vpn etc.
