### PR TITLE
no-resolve when retrieving the ARP table

### DIFF
--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -381,6 +381,7 @@ junos_arp_table:
   rpc: get-arp-table-information
   args:
     expiration-time: true
+    no-resolve: true
   item: arp-table-entry
   key: interface-name
   view: junos_arp_view


### PR DESCRIPTION
Although this is a very tiny change, when he option `no-resolve` is not set the results can be quite detrimental: in the context of routers with very long ARP tables combined with slow DNS, sometimes this can take even 8 minutes, which is ridiculous.
