### PR TITLE
Use OPTICS_NULL_LEVEL const from napalm-base

### DIFF
--- a/napalm_junos/constants.py
+++ b/napalm_junos/constants.py
@@ -14,5 +14,3 @@ OC_NETWORK_INSTANCE_TYPE_MAP = {
     'vpls': 'BGP_VPLS',
     'forwarding': 'L2P2P'
 }
-
-OPTICS_NO_POWER = '- Inf'

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -1442,7 +1442,8 @@ class JunOSDriver(NetworkDriver):
                                 'input_power': {
                                     'instant': (
                                         float(optics['input_power'])
-                                        if optics['input_power'] not in [None, C.OPTICS_NO_POWER]
+                                        if optics['input_power'] not in
+                                        [None, C.OPTICS_NULL_LEVEL]
                                         else 0.0),
                                     'avg': 0.0,
                                     'max': 0.0,
@@ -1451,7 +1452,8 @@ class JunOSDriver(NetworkDriver):
                                 'output_power': {
                                     'instant': (
                                         float(optics['output_power'])
-                                        if optics['output_power'] not in [None, C.OPTICS_NO_POWER]
+                                        if optics['output_power'] not in
+                                        [None, C.OPTICS_NULL_LEVEL]
                                         else 0.0),
                                     'avg': 0.0,
                                     'max': 0.0,
@@ -1461,7 +1463,7 @@ class JunOSDriver(NetworkDriver):
                                     'instant': (
                                         float(optics['laser_bias_current'])
                                         if optics['laser_bias_current'] not in
-                                        [None, C.OPTICS_NO_POWER]
+                                        [None, C.OPTICS_NULL_LEVEL]
                                         else 0.0),
                                     'avg': 0.0,
                                     'max': 0.0,


### PR DESCRIPTION
This constant already existed in napalm-base
But it was missed in https://github.com/napalm-automation/napalm-junos/pull/115
And I have introduced a duplicate constant.
