### PR TITLE
Increasing napalm-base requirement to fix missing 'TRACEROUTE_VRF'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-napalm-base>=0.20.3
+napalm-base>=0.23.0
 junos-eznc


### PR DESCRIPTION
Received this error using napalm-junos with Ansible while running napalm-base-0.21.0.

```
"cannot connect to device: 'module' object has no attribute 'TRACEROUTE_VRF'"

$ pip list | grep napalm-base
napalm-base (0.21.0)
```

Upgrading to napalm-base 0.23.0 fixed the issue.

Basically one of the Pull Requests created a napalm-base dependency that hadn't been properly reflected in requirements.txt.

Note, this probably applies to other napalm platforms.
