### PR TITLE
Fix for zero interfaces in VRF causing TypeError in get_network_inter…

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -1527,8 +1527,8 @@ class JunOSDriver(NetworkDriver):
                 ri_type = 'default'
             ri_rd = ri_details['route_distinguisher']
             ri_interfaces = ri_details['interfaces']
-            if ri_interfaces is None:
-                ri_interfaces = {}
+            if not isinstance(ri_interfaces,list):
+                ri_interfaces = [ri_interfaces]
             network_instances[ri_name] = {
                 'name': ri_name,
                 'type': C.OC_NETWORK_INSTANCE_TYPE_MAP.get(ri_type, ri_type),  # default: return raw

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -1527,7 +1527,7 @@ class JunOSDriver(NetworkDriver):
                 ri_type = 'default'
             ri_rd = ri_details['route_distinguisher']
             ri_interfaces = ri_details['interfaces']
-            if not isinstance(ri_interfaces,list):
+            if not isinstance(ri_interfaces, list):
                 ri_interfaces = [ri_interfaces]
             network_instances[ri_name] = {
                 'name': ri_name,

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -1527,6 +1527,8 @@ class JunOSDriver(NetworkDriver):
                 ri_type = 'default'
             ri_rd = ri_details['route_distinguisher']
             ri_interfaces = ri_details['interfaces']
+            if ri_interfaces is None:
+                ri_interfaces = {}
             network_instances[ri_name] = {
                 'name': ri_name,
                 'type': C.OC_NETWORK_INSTANCE_TYPE_MAP.get(ri_type, ri_type),  # default: return raw


### PR DESCRIPTION
I found a VRF without any interfaces in it causes this to happen.

INFO:ncclient.operations.rpc:Requesting 'ExecuteRpc'
Traceback (most recent call last):
  File "./modeller.py", line 140, in <module>
    sys.exit(main())
  File "./modeller.py", line 114, in main
    data = nd.get_network_instances()
  File "/usr/local/lib/python2.7/dist-packages/napalm_junos/junos.py", line 1541, in get_network_instances
    intrf_name: {} for intrf_name in ri_interfaces if intrf_name
TypeError: 'NoneType' object is not iterable
Segmentation fault (core dumped)