### PR TITLE
Adds optional_arg for enabling keepalives.

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -79,6 +79,7 @@ class JunOSDriver(NetworkDriver):
         self.config_lock = optional_args.get('config_lock', True)
         self.port = optional_args.get('port', 22)
         self.key_file = optional_args.get('key_file', None)
+        self.keepalive = optional_args.get('keepalive', None)
 
         if self.key_file:
             self.device = Device(hostname,
@@ -97,6 +98,8 @@ class JunOSDriver(NetworkDriver):
         except ConnectTimeoutError as cte:
             raise ConnectionException(cte.message)
         self.device.timeout = self.timeout
+        if self.keepalive:
+            self.device._conn._session.transport.set_keepalive(self.keepalive)
         if hasattr(self.device, "cu"):
             # make sure to remove the cu attr from previous session
             # ValueError: requested attribute name cu already exists

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -79,7 +79,7 @@ class JunOSDriver(NetworkDriver):
         self.config_lock = optional_args.get('config_lock', True)
         self.port = optional_args.get('port', 22)
         self.key_file = optional_args.get('key_file', None)
-        self.keepalive = optional_args.get('keepalive', None)
+        self.keepalive = optional_args.get('keepalive', 30)
 
         if self.key_file:
             self.device = Device(hostname,
@@ -98,8 +98,7 @@ class JunOSDriver(NetworkDriver):
         except ConnectTimeoutError as cte:
             raise ConnectionException(cte.message)
         self.device.timeout = self.timeout
-        if self.keepalive:
-            self.device._conn._session.transport.set_keepalive(self.keepalive)
+        self.device._conn._session.transport.set_keepalive(self.keepalive)
         if hasattr(self.device, "cu"):
             # make sure to remove the cu attr from previous session
             # ValueError: requested attribute name cu already exists

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -64,6 +64,7 @@ class JunOSDriver(NetworkDriver):
             * config_lock (True/False): lock configuration DB after the connection is established.
             * port (int): custom port
             * key_file (string): SSH key file path
+            * keepalive (int): Keepalive interval
         """
         self.hostname = hostname
         self.username = username


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>

Had a quick discussion with @mirceaulinic about adding an optional_arg that's passed to Paramiko's `set_keepalive()`. Here's a pretty quick pass at some working code. If I need some tests or refactoring let me know. Thanks!