### PR TITLE
Fixes #150 - Adds more actions to config detection.

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -160,9 +160,21 @@ class JunOSDriver(NetworkDriver):
 
     def _detect_config_format(self, config):
         fmt = 'text'
+        set_action_matches = [
+            'set',
+            'activate',
+            'deactivate',
+            'annotate',
+            'copy',
+            'delete',
+            'insert',
+            'protect',
+            'rename',
+            'unprotect',
+        ]
         if config.strip().startswith('<'):
             return 'xml'
-        elif config.strip().startswith('set'):
+        elif config.split(' ')[0] in set_action_matches:
             return 'set'
         elif self._is_json_format(config):
             return 'json'


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
Seems this approach has a slight edge over using regex.

I had a look at some of the unittests but could find a good fit for this, but admittedly I haven't used pytest before. If someone wanted to point me in the right direction to get started I could add some.