### PR TITLE
Catch ConnectClosedError from junos-eznc

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 import re
 import json
 import logging
+import functools
 import collections
 from copy import deepcopy
 
@@ -64,6 +65,7 @@ def _raise_conn_closed(meth):
     This function can be later extended to raise other
     napalm-specific methods, e.g.: LockError etc.
     '''
+    @functools.wraps(meth)
     def fun(*args, **kwargs):
         try:
             return meth(*args, **kwargs)


### PR DESCRIPTION
And raise ConnectionClosedException from napalm-base.
We can easily raise what we need using a metaclass that
catches the exceptions and raises the desired exception as required.
This models has the advantage that it's easier to raise other kind
of exceptions. We will soon need to raise other new exceptions
from napalm-base, e.g.: LockException, UnlockException etc.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
