### PR TITLE
Strip config text before checking the format type

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -180,7 +180,7 @@ class JunOSDriver(NetworkDriver):
         ]
         if config.strip().startswith('<'):
             return 'xml'
-        elif config.split(' ')[0] in set_action_matches:
+        elif config.strip().split(' ')[0] in set_action_matches:
             return 'set'
         elif self._is_json_format(config):
             return 'json'


### PR DESCRIPTION
Otherwise, if the configuration is loaded and
the first line is blank, load config will fail and
discards the configuration even though everything
else was correct.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
