### PR TITLE
Pass better error from pyez to napalm

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -202,9 +202,9 @@ class JunOSDriver(NetworkDriver):
             self.device.cu.load(configuration, format=fmt, overwrite=overwrite)
         except ConfigLoadError as e:
             if self.config_replace:
-                raise ReplaceConfigException(e.message)
+                raise ReplaceConfigException(e.errs)
             else:
-                raise MergeConfigException(e.message)
+                raise MergeConfigException(e.errs)
 
     def load_replace_candidate(self, filename=None, config=None):
         """Open the candidate config and merge."""


### PR DESCRIPTION
Fixes #184 

This basically improves the returned error message by returning something like this:

```
In [1]: from napalm_base import get_network_driver
   ...: junos_configuration = {
   ...:     'hostname': '127.0.0.1',
   ...:     'username': 'vagrant',
   ...:     'password': '',
   ...:     'optional_args': {'port': 12203, 'config_lock': False}
   ...: }
   ...: junos = get_network_driver("junos")
   ...: junos_device = junos(**junos_configuration)
   ...:
   ...: with junos_device as d:
   ...:     d.load_merge_candidate(config="asdasd")
   ...:
---------------------------------------------------------------------------
MergeConfigException                      Traceback (most recent call last)
<ipython-input-1-6c5a0483b535> in <module>()
     10
     11 with junos_device as d:
---> 12     d.load_merge_candidate(config="asdasd")

/Users/dbarroso/workspace/napalm/napalm-junos/napalm_junos/junos.pyc in load_merge_candidate(self, filename, config)
    215         """Open the candidate config and replace."""
    216         self.config_replace = False
--> 217         self._load_candidate(filename, config, False)
    218
    219     def compare_config(self):

/Users/dbarroso/workspace/napalm/napalm-junos/napalm_junos/junos.pyc in _load_candidate(self, filename, config, overwrite)
    205                 raise ReplaceConfigException(e.errs)
    206             else:
--> 207                 raise MergeConfigException(e.errs)
    208
    209     def load_replace_candidate(self, filename=None, config=None):

MergeConfigException: [{'source': None, 'message': 'syntax error', 'bad_element': 'asdasd', 'severity': 'error', 'edit_path': None}]
```