### PR TITLE
change default cli warning to False

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -660,7 +660,7 @@ class JunOSDriver(NetworkDriver):
 
         for command in commands:
             cli_output[py23_compat.text_type(command)] = py23_compat.text_type(
-                self.device.cli(command))
+                self.device.cli(command, warning=False))
 
         return cli_output
 


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
#183 to ignore warning when executing raw cli to be inline with other platform.