### PR TITLE
Enhance the cli method to allow piping

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -21,7 +21,6 @@ from __future__ import unicode_literals
 import re
 import json
 import logging
-import tempfile
 import collections
 from copy import deepcopy
 from collections import OrderedDict
@@ -86,7 +85,6 @@ class JunOSDriver(NetworkDriver):
         self.keepalive = optional_args.get('keepalive', 30)
         self.ssh_config_file = optional_args.get('ssh_config_file', None)
         self.ignore_warning = optional_args.get('ignore_warning', False)
-        self.temp_dir = optional_args.get('temp_dir', tempfile.gettempdir())
 
         if self.key_file:
             self.device = Device(hostname,
@@ -759,8 +757,8 @@ class JunOSDriver(NetworkDriver):
                                                                                   args=pipe_args)
                 command_safe_parts.append(safe_pipe)
             safe_command = exploded_cmd[0] if not command_safe_parts else\
-                           '{base} | {pipes}'.format(base=exploded_cmd[0],
-                                                     pipes=' | '.join(command_safe_parts))
+                '{base} | {pipes}'.format(base=exploded_cmd[0],
+                                          pipes=' | '.join(command_safe_parts))
             raw_txt = self.device.cli(safe_command, warning=False)
             cli_output[py23_compat.text_type(command)] = py23_compat.text_type(
                 _process_pipe(command, raw_txt))

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -670,10 +670,13 @@ class JunOSDriver(NetworkDriver):
             '''
             Trim specified number of columns from start of line.
             '''
-            newlines = []
-            for line in txt.splitlines():
-                newlines.append(line[length:])
-            return newlines
+            try:
+                newlines = []
+                for line in txt.splitlines():
+                    newlines.append(line[int(length):])
+                return '\n'.join(newlines)
+            except ValueError:
+                return txt
 
         def _except(txt, pattern):
             '''
@@ -690,9 +693,12 @@ class JunOSDriver(NetworkDriver):
             '''
             Display end of output only.
             '''
-            return '\n'.join(
-                txt.splitlines()[(-1)*length:]
-            )
+            try:
+                return '\n'.join(
+                    txt.splitlines()[(-1)*int(length):]
+                )
+            except ValueError:
+                return txt
 
         def _match(txt, pattern):
             '''


### PR DESCRIPTION
One of the most common problems when using the `cli` method in napalm-junos is that Junos does not process the pipes.
If we are anyway at enhancing the cli (https://github.com/napalm-automation/napalm-junos/pull/186) and align it to the behaviour with the other drivers (which can do piping), this PR addresses to process the piping inside napalm-junos.

Ping @sincerywaing this might interest you as well.
Thoughts?