### PR TITLE
Ignore warnings on commit

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -236,7 +236,7 @@ class JunOSDriver(NetworkDriver):
 
     def commit_config(self):
         """Commit configuration."""
-        self.device.cu.commit()
+        self.device.cu.commit(ignore_warning=self.ignore_warning)
         if not self.config_lock:
             self._unlock()
 


### PR DESCRIPTION
If we are anyway ignoring warnings when loading changes
into the candidate, when the user requires to ignore warnings,
this can be applied also when committing.

Ping @sincerywaing - as you've introduced the optional arg in https://github.com/napalm-automation/napalm-junos/pull/180