### PR TITLE
support for 40G interface counters

### DIFF
--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -96,7 +96,7 @@ junos_iface_counter_table:
   rpc: get-interface-information
   args:
     extensive: True
-    interface_name: '[vmfgx][mle]*'
+    interface_name: '[vmfgxe][mlet]*'
   args_key: interface_name
   item: physical-interface
   view: junos_iface_counter_view


### PR DESCRIPTION
I was not able to get the counters from et-XXX interfaces while using get_interfaces_counters(). After changing the yml file I can get the counters from et-XXX and emX interfaces

