### PR TITLE
fix - Inf conversion to float in get_optics()

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -1782,7 +1782,7 @@ class JunOSDriver(NetworkDriver):
                                     'instant': (
                                         float(optics['input_power'])
                                         if optics['input_power'] not in
-                                        [None, C.OPTICS_NULL_LEVEL]
+                                        [None, C.OPTICS_NULL_LEVEL, '- Inf']
                                         else 0.0),
                                     'avg': 0.0,
                                     'max': 0.0,


### PR DESCRIPTION
I was getting the following error while using the get_optics() method
File "/home/devel/napalm-junos/napalm-junos/napalm_junos/junos.py", line 1785, in get_optics
    [None, C.OPTICS_NULL_LEVEL]
ValueError: could not convert string to float: - Inf

The contents of the optics_items list returns:
[('xe-0/0/0', [('output_power', '-1.82'), ('laser_bias_current', '38.282'), ('input_power', '- Inf')]), ('et-0/0/48', [('output_power', None), ('laser_bias_current', Non
e), ('input_power', None)]), ('et-0/0/49', [('output_power', None), ('laser_bias_current', None), ('input_power', None)]), ('et-0/0/50', [('output_power', None), ('laser
_bias_current', None), ('input_power', None)]), ('et-0/0/51', [('output_power', None), ('laser_bias_current', None), ('input_power', None)])]

Not sure if the change needs to be applied in output_power (line 1795) and laser_bias_current (lihe1805)