### PR TITLE
fixes #176 get_facts uptime against patch in pyeznc 2.1.5

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 David Barroso <dbarrosop@dravetech.com>
 Elisa Jasinska <elisa@bigwaveit.org>
+John Anderson <lampwins@gmail.com>

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -39,7 +39,6 @@ from jnpr.junos.exception import ConnectTimeoutError
 # import NAPALM Base
 import napalm_base.helpers
 from napalm_base.base import NetworkDriver
-from napalm_base.utils import string_parsers
 from napalm_base.utils import py23_compat
 import napalm_junos.constants as C
 from napalm_base.exceptions import ConnectionException

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -256,9 +256,7 @@ class JunOSDriver(NetworkDriver):
         """Return facts of the device."""
         output = self.device.facts
 
-        uptime = '0'
-        if 'RE0' in output:
-            uptime = output['RE0']['up_time']
+        uptime = self.device.uptime or -1
 
         interfaces = junos_views.junos_iface_table(self.device)
         interfaces.get()
@@ -271,7 +269,7 @@ class JunOSDriver(NetworkDriver):
             'os_version': py23_compat.text_type(output['version']),
             'hostname': py23_compat.text_type(output['hostname']),
             'fqdn': py23_compat.text_type(output['fqdn']),
-            'uptime': string_parsers.convert_uptime_string_seconds(uptime),
+            'uptime': uptime,
             'interface_list': interface_list
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 napalm-base>=0.24.1
-junos-eznc>=2.1.3
+junos-eznc>=2.1.5

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -73,6 +73,7 @@ class FakeJunOSDevice(BaseTestDouble):
             'vc_capable': False,
             'personality': 'SRX_BRANCH'
         }
+        self._uptime = 4380
 
     @property
     def facts(self):
@@ -87,6 +88,10 @@ class FakeJunOSDevice(BaseTestDouble):
             except (yaml.YAMLError, AttributeError):
                 self._facts = self.default_facts
         return self._facts
+
+    @property
+    def uptime(self):
+        return self._uptime
 
     def open(self):
         pass


### PR DESCRIPTION
<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
The root of #176 was fixed upstream in pyeznc 2.1.5 and required only a small change locally.