### PR TITLE
fix advertised_prefix_count when None

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -1117,7 +1117,10 @@ class JunOSDriver(NetworkDriver):
                 }
                 for rib_entry in neighbor_rib_stats:
                     for elem in rib_entry[1]:
-                        neighbor_rib_details[elem[0]] += elem[1]
+                        if elem[1] is None:
+                            neighbor_rib_details[elem[0]] += 0
+                        else:
+                            neighbor_rib_details[elem[0]] += elem[1]
                 neighbor_details.update(neighbor_rib_details)
                 bgp_neighbors[instance_name][remote_as].append(neighbor_details)
 


### PR DESCRIPTION
I was getting the following error while using `get_bgp_neighbors_detail()` 
```
Traceback (most recent call last):
  File "client_junos_bgp2.py", line 25, in <module>
    res = dev.get_bgp_neighbors_detail(neighbor_address='10.92.99.92')
  File "/home/ckishimo/python/napalm-junos/napalm_junos/junos.py", line 1139, in get_bgp_neighbors_detail
    _bgp_iter_core(neighbor_data, instance=instance)
  File "/home/ckishimo/python/napalm-junos/napalm_junos/junos.py", line 1123, in _bgp_iter_core
    neighbor_rib_details[elem[0]] += elem[1]
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```
It seems the counter value for `advertised_prefix_count` was `None`, the `rib_entry` was:
```
('bgp.evpn.0', [('received_prefix_count', 2), ('active_prefix_count', 2), ('accepted_prefix_count', 2), ('suppressed_prefix_count', 0), ('advertised_prefix_count', None)])
```
However I tested this code with #209 and that PR is fixing this error as well. Just wondering if it's a good idea to merge this one or not

Also issue #178 should be fixed with #209 or with this one. Thanks