### PR TITLE
Improve power supply information in get_enviornment()

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -407,7 +407,7 @@ class JunOSDriver(NetworkDriver):
             # Not all platforms have support for this
             pass
         else:
-            # Format PEM information
+            # Format PEM information and correct capacity and output values
             for pem in power_supplies.items():
                 pem_name = pem[0].replace("PEM", "Power Supply")
                 pem_table[pem_name] = dict(pem[1])

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -321,11 +321,19 @@ class JunOSDriver(NetworkDriver):
         environment = junos_views.junos_enviroment_table(self.device)
         routing_engine = junos_views.junos_routing_engine_table(self.device)
         temperature_thresholds = junos_views.junos_temperature_thresholds(self.device)
+        power_supplies = junos_views.junos_pem_table(self.device)
         environment.get()
         routing_engine.get()
         temperature_thresholds.get()
+        power_supplies.get()
         environment_data = {}
         current_class = None
+
+        # Format PEM information
+        pem_table = dict()
+        for pem in power_supplies.items():
+            pem_name = pem[0].replace("PEM", "Power Supply")
+            pem_table[pem_name] = dict(pem[1])
 
         for sensor_object, object_data in environment.items():
             structured_object_data = {k: v for k, v in object_data}
@@ -347,9 +355,8 @@ class JunOSDriver(NetworkDriver):
                     environment_data['power'] = {}
                     environment_data['power'][sensor_object] = {}
 
-                # Set these values to -1, because Junos does not provide them
-                environment_data['power'][sensor_object]['capacity'] = -1.0
-                environment_data['power'][sensor_object]['output'] = -1.0
+                environment_data['power'][sensor_object]['capacity'] = pem_table[sensor_object]['capacity']
+                environment_data['power'][sensor_object]['output'] = pem_table[sensor_object]['output']
 
             if structured_object_data['class'] == 'Fans':
                 # Create a dict for the 'fans' key

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -412,7 +412,7 @@ class JunOSDriver(NetworkDriver):
                 pem_name = pem[0].replace("PEM", "Power Supply")
                 pem_table[pem_name] = dict(pem[1])
                 environment_data['power'][pem_name]['capacity'] = pem_table[pem_name]['capacity']
-                environment_data['power'][pem_name]['output'] = pem_table[pem_name]['output']               
+                environment_data['power'][pem_name]['output'] = pem_table[pem_name]['output']
 
         for routing_engine_object, routing_engine_data in routing_engine.items():
             structured_routing_engine_data = {k: v for k, v in routing_engine_data}

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -403,7 +403,7 @@ class JunOSDriver(NetworkDriver):
         pem_table = dict()
         try:
             power_supplies.get()
-        except RpcError as rpcerr:
+        except RpcError:
             # Not all platforms have support for this
             pass
         else:

--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -154,8 +154,8 @@ junos_pem_table:
 
 junos_pem_view:
   fields:
-    capacity: { pem-capacity-detail/capacity-actual: int }
-    output: { dc-output-detail/dc-power: int }
+    capacity: { pem-capacity-detail/capacity-actual: float }
+    output: { dc-output-detail/dc-power: float }
 
 junos_routing_engine_table:
   rpc: get-route-engine-information

--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -145,6 +145,19 @@ junos_enviroment_view:
     status: status
     temperature: { temperature/@celsius: int }
 
+junos_pem_table:
+  rpc: get-power-usage-information-detail
+  args:
+  item: power-usage-item
+  key: name
+  view: junos_pem_view
+
+junos_pem_view:
+  fields:
+    state: state
+    capacity: { pem-capacity-detail/capacity-actual: int }
+    output: { dc-output-detail/dc-power: int }
+
 junos_routing_engine_table:
   rpc: get-route-engine-information
   args:

--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -154,7 +154,6 @@ junos_pem_table:
 
 junos_pem_view:
   fields:
-    state: state
     capacity: { pem-capacity-detail/capacity-actual: int }
     output: { dc-output-detail/dc-power: int }
 

--- a/test/unit/mocked_data/test_get_environment/normal/get-power-usage-information-detail.xml
+++ b/test/unit/mocked_data/test_get_environment/normal/get-power-usage-information-detail.xml
@@ -1,0 +1,4 @@
+<power-usage-information>
+   <power-usage-item>
+   </power-usage-item>
+</power-usage-information>

--- a/test/unit/mocked_data/test_get_environment/virtualchassis/get-power-usage-information-detail.xml
+++ b/test/unit/mocked_data/test_get_environment/virtualchassis/get-power-usage-information-detail.xml
@@ -1,0 +1,4 @@
+<power-usage-information>
+   <power-usage-item>
+   </power-usage-item>
+</power-usage-information>


### PR DESCRIPTION
This PR will improve the output of get_environment(), as the command `show chassis power` available in some platforms reports capacity and output per power supply

```
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/17.3R1/junos">
    <rpc>
        <get-power-usage-information>
        </get-power-usage-information>
    </rpc>
    <cli>
        <banner></banner>
    </cli>
</rpc-reply>
```

Example:
```
user@juniper> show chassis power                      

PEM 0:
  State:     Online
  Capacity:  2700 W (maximum 2700 W)
  DC output: 612 W (zone 0, 51 A at 12 V, 22% of capacity)

PEM 1:
  State:     Online
  Capacity:  2700 W (maximum 2700 W)
  DC output: 612 W (zone 0, 51 A at 12 V, 22% of capacity)

PEM 2:
  State:     Online
  Capacity:  2700 W (maximum 2700 W)
  DC output: 612 W (zone 0, 51 A at 12 V, 22% of capacity)

PEM 3:
  State:     Online
  Capacity:  2700 W (maximum 2700 W)
  DC output: 624 W (zone 0, 52 A at 12 V, 23% of capacity)
```
The output from get_environment() will be now:
```
    "power": {
        "Power Supply 0": {
            "capacity": 2700, 
            "output": 612, 
            "status": true
        }, 
        "Power Supply 1": {
            "capacity": 2700, 
            "output": 612, 
            "status": true
        }, 
        "Power Supply 2": {
            "capacity": 2700, 
            "output": 612, 
            "status": true
        }, 
        "Power Supply 3": {
            "capacity": 2700, 
            "output": 624, 
            "status": true
        }, 
        .....
```
Let me know. Thanks
