### PR TITLE
fix route_reflector_client in get_bgp_config()

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -999,6 +999,8 @@ class JunOSDriver(NetworkDriver):
                         bgp_peer_details['remote_as'])
                     if key == 'cluster':
                         bgp_peer_details['route_reflector_client'] = True
+                        # we do not want cluster in the output
+                        del bgp_peer_details['cluster']
 
                 if 'cluster' in bgp_config[bgp_group_name].keys():
                     bgp_peer_details['route_reflector_client'] = True

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -885,7 +885,6 @@ class JunOSDriver(NetworkDriver):
             'type': py23_compat.text_type,
             'apply_groups': list,
             'remove_private_as': bool,
-            'cluster': py23_compat.text_type,
             'multipath': bool,
             'multihop_ttl': int
         }
@@ -983,7 +982,7 @@ class JunOSDriver(NetworkDriver):
                         bgp_peer_details['local_as'])
                     bgp_peer_details['remote_as'] = napalm_base.helpers.as_number(
                         bgp_peer_details['remote_as'])
-                if bgp_config[bgp_group_name]['cluster']:
+                if 'cluster' in bgp_config[bgp_group_name].keys():
                     bgp_peer_details['route_reflector_client'] = True
                 prefix_limit_fields = {}
                 for elem in bgp_group_details:
@@ -998,6 +997,10 @@ class JunOSDriver(NetworkDriver):
                 bgp_config[bgp_group_name]['neighbors'][bgp_peer_address] = bgp_peer_details
                 if neighbor and bgp_peer_address == neighbor_ip:
                     break  # found the desired neighbor
+
+        if 'cluster' in bgp_config[bgp_group_name].keys():
+            # we do not want cluster in the output
+            del bgp_config[bgp_group_name]['cluster']
 
         return bgp_config
 

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -982,6 +982,9 @@ class JunOSDriver(NetworkDriver):
                         bgp_peer_details['local_as'])
                     bgp_peer_details['remote_as'] = napalm_base.helpers.as_number(
                         bgp_peer_details['remote_as'])
+                    if key == 'cluster':
+                        bgp_peer_details['route_reflector_client'] = True
+
                 if 'cluster' in bgp_config[bgp_group_name].keys():
                     bgp_peer_details['route_reflector_client'] = True
                 prefix_limit_fields = {}

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -885,6 +885,7 @@ class JunOSDriver(NetworkDriver):
             'type': py23_compat.text_type,
             'apply_groups': list,
             'remove_private_as': bool,
+            'cluster': py23_compat.text_type,
             'multipath': bool,
             'multihop_ttl': int
         }
@@ -982,6 +983,8 @@ class JunOSDriver(NetworkDriver):
                         bgp_peer_details['local_as'])
                     bgp_peer_details['remote_as'] = napalm_base.helpers.as_number(
                         bgp_peer_details['remote_as'])
+                if bgp_config[bgp_group_name]['cluster']:
+                    bgp_peer_details['route_reflector_client'] = True
                 prefix_limit_fields = {}
                 for elem in bgp_group_details:
                     if '_prefix_limit' in elem[0] and elem[1] is not None:

--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -280,6 +280,7 @@ junos_bgp_config_peers_view:
     export_policy: {export: unicode}
     local_address: {local-address: unicode}
     local_as: {ocal-as: int}
+    cluster: cluster
     remote_as: {peer-as: int}
     authentication_key: {authentication_key: unicode}
     inet_unicast_limit_prefix_limit: {family/inet/unicast/prefix-limit/maximum: int}

--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -245,6 +245,7 @@ junos_bgp_config_view:
     multihop_ttl: {multihop/ttl: int}
     local_as: {local-as/as-number: int}
     remote_as: {peer-as: int}
+    cluster: cluster
     multipath: multipath
     remove_private_as: remove-private
     import_policy: {import: unicode}


### PR DESCRIPTION
This fixes the `route_reflector_client` key in `get_bgp_config()`, as far as I can see it's always set to `False`. This should work when applying the `cluster` command in group or neighbors level, but not in global config. As far as I can see all commands applied globally are ignored, not sure if there is a reason for that. 
With the following configuration example:
```
group internal {
    type internal;
    local-address 10.99.1.2;
    cluster 6.6.6.6;
    neighbor 10.10.10.10 {
        description routerA;
    }
    neighbor 20.20.20.20 {
        description routerB;
    }
}
```
both neighbors are route reflectors clients:
```
carles@vmx# run show bgp neighbor | display xml | match "peer-address|client" 
            <peer-address>10.10.10.10</peer-address>
            <route-reflector-client/>
            <peer-address>20.20.20.20</peer-address>
            <route-reflector-client/>
```
so the output from get_bgp_config() should be:
```
        "neighbors": {
            "10.10.10.10": {
                "description": "routerA", 
                "route_reflector_client": true
            "20.20.20.20": {
                "description": "routerB", 
                "route_reflector_client": true
```
Please let me know if I missed something or if it's breaking other things...thanks