### PR TITLE
fix multihop ttl to its default value in get_bgp_config()

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -965,6 +965,12 @@ class JunOSDriver(NetworkDriver):
                             napalm_base.helpers.convert(datatype, elem[1], default)
                     })
             bgp_config[bgp_group_name]['prefix_limit'] = build_prefix_limit(**prefix_limit_fields)
+            if 'multihop' in bgp_config[bgp_group_name].keys():
+                # Delete 'multihop' key from the output
+                del bgp_config[bgp_group_name]['multihop']
+                if bgp_config[bgp_group_name]['multihop_ttl'] == 0:
+                    # Set ttl to default value 64
+                    bgp_config[bgp_group_name]['multihop_ttl'] = 64
 
             bgp_config[bgp_group_name]['neighbors'] = {}
             for bgp_group_neighbor in bgp_group_peers.items():

--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -254,6 +254,7 @@ junos_bgp_config_view:
     description: {description: unicode}
     apply_groups: {apply-groups: unicode}
     local_address: {local-address: unicode}
+    multihop: multihop
     multihop_ttl: {multihop/ttl: int}
     local_as: {local-as/as-number: int}
     remote_as: {peer-as: int}


### PR DESCRIPTION
This fixes the `multihop_ttl` value in `get_bgp_config()` when the `multihop` command is configured but without an specific `ttl` value. So the following configuration:
```
group internal {
    type internal;
    multihop;
    local-address 10.99.1.2;
    neighbor 10.10.10.10 {
        description routerA;
        cluster 2.2.2.2;
    }
    neighbor 20.20.20.20 {
        description routerB;
    }
}
```
returns a multihop_ttl value of 0
```
{
    "internal": {
        "apply_groups": [],
        "description": "",
        "export_policy": "",
        "import_policy": "",
        "local_address": "10.99.1.2",
        "local_as": 0,
        "multihop_ttl": 0,
        "multipath": false,
        "neighbors": {
                .....
}
```
when I believe it should be set to its default value. Now the problem is how to determine its default value (I ignore if that changes across platforms and versions), so I set it to the default value 64 (according to Junos documentation). Please let me know. Thanks

```
    "internal": {
        "apply_groups": [],
        "description": "",
        "export_policy": "",
        "import_policy": "",
        "local_address": "10.99.1.2",
        "local_as": 0,
        "multihop_ttl": 64,
        "multipath": false,
        "neighbors": {
```