### PR TITLE
implement find operation in cli

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -760,9 +760,9 @@ class JunOSDriver(NetworkDriver):
             Search for first occurrence of pattern.
             '''
             rgx = '^.*({pattern})(.*)$'.format(pattern=pattern)
-            match = re.search(rgx, txt, re.I|re.M|re.DOTALL)
+            match = re.search(rgx, txt, re.I | re.M | re.DOTALL)
             if match:
-                return '{pattern}{rest}'.format(pattern=pattern,rest=match.group(2))
+                return '{pattern}{rest}'.format(pattern=pattern, rest=match.group(2))
             else:
                 return '\nPattern not found'
 

--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -755,6 +755,17 @@ class JunOSDriver(NetworkDriver):
             ]
             return '\n'.join(matched)
 
+        def _find(txt, pattern):
+            '''
+            Search for first occurrence of pattern.
+            '''
+            rgx = '^.*({pattern})(.*)$'.format(pattern=pattern)
+            match = re.search(rgx, txt, re.I|re.M|re.DOTALL)
+            if match:
+                return '{pattern}{rest}'.format(pattern=pattern,rest=match.group(2))
+            else:
+                return '\nPattern not found'
+
         def _process_pipe(cmd, txt):
             '''
             Process CLI output from Juniper device that
@@ -768,6 +779,7 @@ class JunOSDriver(NetworkDriver):
             _OF_MAP['last'] = _last
             _OF_MAP['trim'] = _trim
             _OF_MAP['count'] = _count
+            _OF_MAP['find'] = _find
             # the operations order matter in this case!
             exploded_cmd = cmd.split('|')
             pipe_oper_args = {}


### PR DESCRIPTION
Just for completeness, implementation of the `find` operation, same as `match`, `last`, `except`....using the `find` operation in junos cli was not giving the right output. With the following configuration:
```
carles@vmx> show configuration protocols bgp 
local-as 1111;
group internal {
    type internal;
    local-address 10.99.1.2;
    neighbor 10.10.10.10 {
        description routerA;
        cluster 2.2.2.2;
    }
    neighbor 20.20.20.20 {
        description routerB;
    }
}
```
the output should be:
```
carles@vmx> show configuration protocols bgp | find cluster 
        cluster 2.2.2.2;
    }
    neighbor 20.20.20.20 {
        description routerB;
    }
}
```
and not:
```
res = dev.cli(["show configuration protocols bgp | find cluster"])
{
    "show configuration protocols bgp | find cluster": "\nlocal-as 1111;\ngroup internal {\n    type internal;\n    local-address 10.99.1.2;\n    neighbor 10.10.10.10 {\n        description routerA;\n        cluster 2.2.2.2;\n    }\n    neighbor 20.20.20.20 {\n        description routerB;\n    }\n}\n"
}
```
with the new operation the output is:
```
{
    "show configuration protocols bgp | find cluster": "cluster 2.2.2.2;\n    }\n    neighbor 20.20.20.20 {\n        description routerB;\n    }\n}\n"
}
```
If the pattern does not exist we return the same junos message:
```
{
    "show configuration protocols bgp | find napalm": "\nPattern not found"
}
```
and in junos cli:
```
carles@vmx> show configuration protocols bgp | find napalm     

Pattern not found
carles@vmx> 
```
