### PR TITLE
fix family in get_bgp_neighbors()

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -459,7 +459,7 @@ class JunOSDriver(NetworkDriver):
             'inet6': 'ipv6',
             'inetflow': 'flow'
         }
-        family = table.split('.')[-2]
+        family = table.rsplit('.',1)[-2]
         try:
             address_family = address_family_mapping[family]
         except KeyError:
@@ -488,6 +488,9 @@ class JunOSDriver(NetworkDriver):
                 neighbor['sent_prefixes'] = [neighbor['sent_prefixes']]
             for idx, table in enumerate(neighbor['tables']):
                 family = self._get_address_family(table)
+                if family.startswith('__'):
+                   # junos internal instances
+                   continue
                 data[family] = {}
                 data[family]['received_prefixes'] = neighbor['received_prefixes'][idx]
                 data[family]['accepted_prefixes'] = neighbor['accepted_prefixes'][idx]


### PR DESCRIPTION
This fixes the `address_family` name reported in `get_bgp_neighbors()`. After configuring `evpn`, there are two tables reported `bgp.evpn.0` and `default-switch.evpn.0`. With the current code, both families are merged into a single table called `evpn`, but then the results of `accepted/received/sent_prefixes` are not correct
With the current code:
```
            "10.92.99.92": {
                "address_family": {
                    "evpn": {
                        "accepted_prefixes": 1, 
                        "received_prefixes": 1, 
                        "sent_prefixes": 0
                    }, 
```
With the new code:
```
                "address_family": {
                    "bgp.evpn": {
                        "accepted_prefixes": 1, 
                        "received_prefixes": 1, 
                        "sent_prefixes": 14
                    }, 
                    "default-switch.evpn": {
                        "accepted_prefixes": 1, 
                        "received_prefixes": 1, 
                        "sent_prefixes": 0
                    }, 
```
This is breaking the mocked data for get_bgp_neighbors.....please let me know what you think. Thanks
