### PR TITLE
suppress FutureWarning

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -760,7 +760,7 @@ class JunOSDriver(NetworkDriver):
             Process CLI output from Juniper device that
             doesn't allow piping the output.
             '''
-            if not txt:
+            if txt is not None:
                 return txt
             _OF_MAP = OrderedDict()
             _OF_MAP['except'] = _except


### PR DESCRIPTION
This fixes the `FutureWarning`
```
/junos.py:763: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if not txt:
{
    "show configuration protocols bgp | append file": "<Element abort at 0x7f27ce5cf830>"
}
```
