### PR TITLE
fix removal of cluster key

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -1018,9 +1018,9 @@ class JunOSDriver(NetworkDriver):
                 if neighbor and bgp_peer_address == neighbor_ip:
                     break  # found the desired neighbor
 
-        if 'cluster' in bgp_config[bgp_group_name].keys():
-            # we do not want cluster in the output
-            del bgp_config[bgp_group_name]['cluster']
+            if 'cluster' in bgp_config[bgp_group_name].keys():
+                # we do not want cluster in the output
+                del bgp_config[bgp_group_name]['cluster']
 
         return bgp_config
 


### PR DESCRIPTION
This fixes the bug created by myself yesterday (sorry!) related to #214. The `cluster` key should be removed in each group, so it must be done inside the main loop, and not outside. With the current code having 2 internal groups will have the `cluster` only removed in the last group, but not the others:
```
{
    "internal": {
        "apply_groups": [], 
        "cluster": null, 
        "description": "", 
        .....
    }, 
    "internal2": {
        "apply_groups": [], 
        "description": "", 
        .....
    }, 
 }
```