### PR TITLE
support global commands in get_bgp_config()

### DIFF
--- a/napalm_junos/utils/junos_views.yml
+++ b/napalm_junos/utils/junos_views.yml
@@ -237,6 +237,13 @@ junos_lldp_neighbors_detail_view:
 ### BGP config
 ###
 
+junos_bgp_global_config_table:
+  get: protocols/bgp
+  # In order to avoid the creation of a new table, we will assume
+  # all options in group config are available in global config and
+  # remove the options not avaiable within get_bgp_config()
+  view: junos_bgp_config_view
+  key: .
 
 junos_bgp_config_table:
   get: protocols/bgp/group


### PR DESCRIPTION
This provides support for `BGP` commands applied globally as they are currently ignored. Now, I don't know how to return this data, I just included a new key called `GLOBAL`, but not sure if there is a better approach
```
{
    "GLOBAL": {
        "apply_groups": [], 
        "description": "", 
        "export_policy": "p1", 
        "import_policy": "p2", 
        "local_address": "", 
        "local_as": 1111, 
        "multihop_ttl": 64, 
        "prefix_limit": {}, 
        "remove_private_as": true
    }, 
    "internal": {
        "apply_groups": [], 
        "cluster": null, 
        "description": "", 
```
This is breaking the tests using the mocked data.... but before fixing that it would be good to know if this PR is approved or not. Thanks