### PR TITLE
Pass password when using ssh key

### DIFF
--- a/napalm_junos/junos.py
+++ b/napalm_junos/junos.py
@@ -88,6 +88,7 @@ class JunOSDriver(NetworkDriver):
         if self.key_file:
             self.device = Device(hostname,
                                  user=username,
+                                 password=password,
                                  ssh_private_key_file=self.key_file,
                                  ssh_config=self.ssh_config_file,
                                  port=self.port)


### PR DESCRIPTION
Currently it is not possible to use a ssh key with a passphrase.

`paramiko` defines `password` as follows:

```
password (str) – a password to use for authentication or for unlocking a
private key
```

This change passes the password when using a private key allowing the
use of a passphrase protected private key.

<!-- Make sure you have read http://napalm.readthedocs.io/en/latest/contributing/index.html --!>
